### PR TITLE
CLI command fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To install this library from github, you just need to run `haxelib git beluga ht
 
 To setup a new project, you can use the tool provided with haxelib.
 
-`haxelib run beluga setup project_name`
+`haxelib run beluga setup_project project_name`
 
 You can get more tool's commands with `haxelib run beluga help`
 


### PR DESCRIPTION
`beluga setup` should be `beluga setup_project` as also apparent from `beluga help`: 

```
$ haxelib run beluga help
Usage:
    * help
    * setup_project project_name
    * create_module module_name
        * Must be run inside a beluga's project folder
```
